### PR TITLE
[WW-7333] Upgrade to ruby 3.1.3 with backward compatibility 2.7.7

### DIFF
--- a/elected.gemspec
+++ b/elected.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'redlock', '0.1.3'
+  spec.add_dependency 'redlock'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'pry'
 

--- a/lib/elected/version.rb
+++ b/lib/elected/version.rb
@@ -1,3 +1,3 @@
 module Elected
-  VERSION = '0.2.5'
+  VERSION = '0.2.6'
 end


### PR DESCRIPTION
Upgrade to ruby 3.1.3 with backward compatibility 2.7.7

Ticket: WW-7333
Url: https://datafeedwatch.atlassian.net/browse/WW-7333